### PR TITLE
Type improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
-        "contensis-core-api": "1.1.0",
+        "contensis-core-api": "^1.1.1",
         "cross-fetch": "^3.1.5",
         "es6-promise": "^4.2.6",
         "tslib": "^1.10.0",
@@ -1318,9 +1318,9 @@
       "dev": true
     },
     "node_modules/contensis-core-api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/contensis-core-api/-/contensis-core-api-1.1.0.tgz",
-      "integrity": "sha512-AilPLHdeb/em2uFEOqQgh8r8Nk9X3rC+MHKrds+1ea4e+JHT7h6UB+3rE06zEfGlN4JCwoqjzuHozUOUgPUdCw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/contensis-core-api/-/contensis-core-api-1.1.1.tgz",
+      "integrity": "sha512-imzOeBrfcKevwdEXDY24jhz7CgDGMpXQQA10a+Qs36VWYdv9PA2KeuIjN0H0eoaKUPzKsDbitzr6CZyWwaPveA==",
       "dependencies": {
         "@types/detect-node": "^2.0.0",
         "detect-node": "^2.0.4",
@@ -9176,9 +9176,9 @@
       "dev": true
     },
     "contensis-core-api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/contensis-core-api/-/contensis-core-api-1.1.0.tgz",
-      "integrity": "sha512-AilPLHdeb/em2uFEOqQgh8r8Nk9X3rC+MHKrds+1ea4e+JHT7h6UB+3rE06zEfGlN4JCwoqjzuHozUOUgPUdCw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/contensis-core-api/-/contensis-core-api-1.1.1.tgz",
+      "integrity": "sha512-imzOeBrfcKevwdEXDY24jhz7CgDGMpXQQA10a+Qs36VWYdv9PA2KeuIjN0H0eoaKUPzKsDbitzr6CZyWwaPveA==",
       "requires": {
         "@types/detect-node": "^2.0.0",
         "detect-node": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "3.12.0"
   },
   "dependencies": {
-    "contensis-core-api": "1.1.0",
+    "contensis-core-api": "^1.1.1",
     "cross-fetch": "^3.1.5",
     "es6-promise": "^4.2.6",
     "tslib": "^1.10.0",

--- a/src/models/AssetSys.ts
+++ b/src/models/AssetSys.ts
@@ -1,0 +1,12 @@
+import { BaseSys } from './BaseSys';
+
+export interface AssetSys extends BaseSys<'asset'> {
+    properties: {
+        filename: string;
+        fileSize: number;
+        fileId: string;
+        filePath: string;
+        width?: number;
+        height?: number;
+    };
+}

--- a/src/models/BaseSys.ts
+++ b/src/models/BaseSys.ts
@@ -1,0 +1,21 @@
+import { VersionInfo, VersionStatus } from 'contensis-core-api';
+import { Workflow } from './Workflow';
+import { ClassicMetadata } from './ClassicMetadata';
+import { ContentTypeFormat } from 'contensis-core-api';
+
+export interface BaseSys<T extends ContentTypeFormat> {
+    availableLanguages?: string[];
+    contentTypeId: string;
+    dataFormat: T;
+    id: string;
+    isPublished?: boolean;
+    language: string;
+    owner?: string;
+    projectId?: string;
+    slug?: string;
+    uri?: string;
+    version?: VersionInfo;
+    versionStatus: VersionStatus;
+    workflow?: Workflow;
+    metadata?: ClassicMetadata;
+}

--- a/src/models/ClassicMetadata.ts
+++ b/src/models/ClassicMetadata.ts
@@ -1,0 +1,8 @@
+export interface ClassicMetadata {
+    [key: string]: any;
+    includeInAToZ?: boolean;
+    includeInSearch?: boolean;
+    includeInSiteMap?: boolean;
+    includeInMenu?: boolean;
+    nodeId?: string;
+}

--- a/src/models/ContensisFields.ts
+++ b/src/models/ContensisFields.ts
@@ -1,0 +1,44 @@
+import { EntryAsset } from './Entry';
+
+export interface Asset extends EntryAsset {
+    altText?: string;
+    description?: string;
+    keywords?: string[];
+    thumbnail?: string;
+    title: string;
+}
+
+export interface Image {
+    altText?: string;
+    transformations?: string;
+    caption?: string;
+    asset: Asset;
+}
+
+export interface Composer<T extends string = string, V = any> {
+    type: T;
+    value: V;
+}
+
+export interface DateRange {
+    from: string;
+    to: string;
+}
+
+export interface Quote {
+    text: string;
+    source: string;
+}
+
+export interface Location {
+    lon: number;
+    lat: number;
+}
+
+export interface Taxonomy {
+    path: string;
+    key: string;
+    hasChildren: boolean;
+    name: string;
+    children: Taxonomy[] | [];
+}

--- a/src/models/Entry.ts
+++ b/src/models/Entry.ts
@@ -1,16 +1,21 @@
 import { EntrySys } from './EntrySys';
-
-export interface Entry {
-	sys: EntrySys;
-	[key: string]: any;
-
-	entryTitle?: string;
+import { AssetSys } from './AssetSys';
+import { Image } from './ContensisFields';
+interface BaseEntryFields {
+	entryTitle: string;
 	entryDescription?: string;
-	entryThumbnail?: EntryThumbnail;
+	entryThumbnail?: Image;
 }
 
-export interface EntryThumbnail {
-	altText?: string;
-	caption?: string;
-	asset?: Entry;
+export interface Entry extends StrictEntry {
+	[key: string]: any;
 }
+
+export interface EntryAsset extends BaseEntryFields {
+	sys: AssetSys;
+}
+
+export interface StrictEntry extends BaseEntryFields {
+	sys: EntrySys;
+}
+

--- a/src/models/EntrySys.ts
+++ b/src/models/EntrySys.ts
@@ -1,25 +1,7 @@
-import { VersionInfo } from 'contensis-core-api';
-import { Workflow } from './Workflow';
+import { BaseSys } from './BaseSys';
 
-export interface EntrySys {
+export interface EntrySys extends BaseSys<'entry'> {
 	allUris: string[];
-	availableLanguages?: string[];
-	contentTypeId: string;
-	dataFormat: string;
-	id: string;
-	isPublished?: boolean;
-	language: string;
-	owner?: string;
-	projectId?: string;
-	properties?: {
-		[key: string]: any;
-		width?: number;
-		height?: number;
-		fileSize?: number;
-	};
-	slug?: string;
-	uri: string;
-	version?: VersionInfo;
-	versionStatus: 'published' | 'latest';
-	workflow?: Workflow;
+	metadata: { [key: string]: any };
+	properties: { [key: string]: any };
 }

--- a/src/models/Node.ts
+++ b/src/models/Node.ts
@@ -1,9 +1,9 @@
 import { VersionInfo } from 'contensis-core-api';
-import { Entry } from './Entry';
+import { Entry as LooseEntry, StrictEntry } from './Entry';
 
 export type NodeVersionInfo = Pick<VersionInfo, 'versionNo'>;
 
-export interface Node {
+export interface Node<TEntry extends StrictEntry = LooseEntry> {
     id: string;
     parentId?: string;
     projectId: string;
@@ -13,12 +13,8 @@ export interface Node {
     path: string;
     childCount: number;
     children?: Node[];
-    entry?: Entry;
+    entry?: TEntry;
     isCanonical: boolean;
     version: NodeVersionInfo;
     includeInMenu: boolean;
-
-    // these are management api elements
-    title: string;
-    entryId?: string;
 }


### PR DESCRIPTION
Overview of changes:

- Added `BaseSys` as a way to define `Sys` definitions. Refactored `EntrySys` to utilise this definition and added a new `AssetSys`.
- Added missing `ClassicMetadata` interface
- Added `ContensisFields` which includes interfaces for a variety of entry fields in Contensis
- Refactored `Entry` somewhat. Added a new `StrictEntry` definition to opt-in for stricter types
- Removed incorrect types from Node definition. Added a generic for defining a Node's Entry model

Reviewed briefly with @nflatley-zengenti 